### PR TITLE
restored form validation functionality by adding ID to submit button

### DIFF
--- a/views/pages/auth/addnew-detail.ejs
+++ b/views/pages/auth/addnew-detail.ejs
@@ -200,6 +200,6 @@
     </fieldset>
   </div>
   <input class="hidden" name="timestamp" id="timestamp">
-  <button type="submit">Submit</button>
+  <button type="submit" id="submit-button">Submit</button>
   </form>
 </main>

--- a/views/pages/auth/edit-details.ejs
+++ b/views/pages/auth/edit-details.ejs
@@ -259,6 +259,6 @@
   <input class="hidden" name="timestamp" id="timestamp">
   <p class="script hidden"><span class="emphasis">Even if no updates were made to this organization's information, hit
       the submit button below so it is noted that this record has been checked.</span></p>
-  <button type="submit">Submit</button>
+  <button type="submit" id="submit-button">Submit</button>
   </form>
 </main>


### PR DESCRIPTION
I found out that the form validation code had already been written. (It's in app.js, not server.js.) So, all I had to do was add the correct ID to the submit button.